### PR TITLE
update imports for go/types, in stdlib since go1.5

### DIFF
--- a/go-nyet.go
+++ b/go-nyet.go
@@ -7,12 +7,11 @@ import (
 	"go/build"
 	"go/parser"
 	"go/token"
+	"go/types"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"golang.org/x/tools/go/types"
 )
 
 var debug = flag.Bool("debug", false, "Enable debug printing.")


### PR DESCRIPTION
currently attempt to build the repository or `go get` the package fails with this error:
```
$ go install
go-nyet.go:15:2: no Go files in $GOPATH/src/golang.org/x/tools/go/types
```

PR changes the import to `go/types` which is in stdlib since go1.5 - https://golang.org/doc/go1.5#go_types

(btw it probably would be good to add a travis build to check that the repo builds OK... )